### PR TITLE
Make more space-efficient

### DIFF
--- a/src/VectorBackedLists.jl
+++ b/src/VectorBackedLists.jl
@@ -71,9 +71,9 @@ function list(data)
     n = length(data)
     nodes = Vector{Node}(undef, n+2)
     nodes[1] = Node(0,2,0)
-    for i in 2:n+1; nodes[i] = Node(i-1, i+1, i-1); end
+    for i in 2:n+1; nodes[i] = Node(UInt(i-1), UInt(i+1), UInt(i-1)); end
     nodes[end] = Node(0,0,n+1)
-    VectorBackedList{eltype(data), typeof(data)}(data, nodes, 1, n+2)
+    VectorBackedList{eltype(data), typeof(data)}(data, nodes, UInt32(1), UInt32(n+2))
 end
 
 """

--- a/src/VectorBackedLists.jl
+++ b/src/VectorBackedLists.jl
@@ -6,15 +6,15 @@ export start, next, done
 
 struct Node{T}
     value::T    # index into value of the accompanying value
-    next::Int   # index into nodes of the next node
-    prev::Int   # index into nodes of the previous node
+    next::UInt32 # index into nodes of the next node
+    prev::UInt32 # index into nodes of the previous node
 end
 
 struct VectorBackedList{T,S<:AbstractVector{T}}
     data::S
-    nodes::Vector{Node{Int}}
-    head::Int
-    tail::Int
+    nodes::Vector{Node{UInt32}}
+    head::UInt32
+    tail::UInt32
 end
 
 Base.eltype(::Type{VectorBackedList{T,S}}) where {S,T} = T
@@ -30,7 +30,7 @@ end
     done(iterable) -> state
 
 Produces an iterator state for which `done(iterable,state) == true`. Cf. to the
-c++ end() api.
+C++ end() API.
 """
 done(list::VectorBackedList) = list.tail
 Base.setindex!(list::VectorBackedList, v, state) = (list.data[list.nodes[state].value] = v)

--- a/src/VectorBackedLists.jl
+++ b/src/VectorBackedLists.jl
@@ -71,7 +71,7 @@ function list(data)
     n = length(data)
     nodes = Vector{Node}(undef, n+2)
     nodes[1] = Node(0,2,0)
-    for i in 2:n+1; nodes[i] = Node(UInt(i-1), UInt(i+1), UInt(i-1)); end
+    for i in 2:n+1; nodes[i] = Node(UInt(i-1), UInt32(i+1), UInt32(i-1)); end
     nodes[end] = Node(0,0,n+1)
     VectorBackedList{eltype(data), typeof(data)}(data, nodes, UInt32(1), UInt32(n+2))
 end

--- a/src/VectorBackedLists.jl
+++ b/src/VectorBackedLists.jl
@@ -4,15 +4,15 @@ export list, insert_after!, move_before!, prev, sublist, advance
 
 export start, next, done
 
-struct Node{T}
-    value::T    # index into value of the accompanying value
-    next::UInt32 # index into nodes of the next node
-    prev::UInt32 # index into nodes of the previous node
+struct Node
+    value::UInt32 # index into value of the accompanying value
+    next::UInt32  # index into nodes of the next node
+    prev::UInt32  # index into nodes of the previous node
 end
 
 struct VectorBackedList{T,S<:AbstractVector{T}}
     data::S
-    nodes::Vector{Node{UInt32}}
+    nodes::Vector{Node}
     head::UInt32
     tail::UInt32
 end

--- a/src/VectorBackedLists.jl
+++ b/src/VectorBackedLists.jl
@@ -70,9 +70,9 @@ state of the underlying container.
 function list(data)
     n = length(data)
     nodes = Vector{Node}(undef, n+2)
-    nodes[1] = Node(0,2,0)
+    nodes[1] = Node(UInt32(0), UInt32(2), UInt32(0))
     for i in 2:n+1; nodes[i] = Node(UInt(i-1), UInt32(i+1), UInt32(i-1)); end
-    nodes[end] = Node(0,0,n+1)
+    nodes[end] = Node(UInt32(0), UInt32(0), UInt32(n+1))
     VectorBackedList{eltype(data), typeof(data)}(data, nodes, UInt32(1), UInt32(n+2))
 end
 


### PR DESCRIPTION
Trade-off: Limited to 4 billion long on 64-bit (as on 32-bit), per list.